### PR TITLE
fix: replace order-dependent scoring amplifier and smoothen TF-IDF

### DIFF
--- a/index_creation/searcher.py
+++ b/index_creation/searcher.py
@@ -120,23 +120,24 @@ class Searcher:
 
     def _calc_tf_idf(self, q_tokens, docs):
         scores = defaultdict(float)
-        # visited = set()
+        term_hits = defaultdict(int)
         for t in q_tokens:
             postings = self._get_postings(t)
             if not postings:
                 continue
             df = self.document_freqs.get(t, 1)
-            idf = math.log(self.total_docs / df) 
+            idf = math.log(1 + self.total_docs / df)
             for id in docs:
                 if id in postings:
                     tf = postings[id]["c"]
-                    tf_idf = 0 
                     if tf > 0:
-                        tf_idf = (1+math.log(tf)) * idf * postings[id]["s"]
-                    if id in scores:
-                        scores[id] = (scores[id] + tf_idf) * 4 if t not in STOP_WORDS else (scores[id] + tf_idf)
-                    else:
-                        scores[id] += tf_idf
+                        scores[id] += (1 + math.log(tf)) * idf * postings[id]["s"]
+                    if t not in STOP_WORDS:
+                        term_hits[id] += 1
+
+        for id in scores:
+            if term_hits[id] > 1:
+                scores[id] *= term_hits[id] ** 2
 
         return dict(scores)
     

--- a/index_creation/searcher.py
+++ b/index_creation/searcher.py
@@ -130,14 +130,18 @@ class Searcher:
             for id in docs:
                 if id in postings:
                     tf = postings[id]["c"]
-                    if tf > 0:
+                    # Only accumulate score and count coverage for non-stop-word terms
+                    # to keep score accumulation and term_hits consistent
+                    if tf > 0 and t not in STOP_WORDS:
                         scores[id] += (1 + math.log(tf)) * idf * postings[id]["s"]
-                    if t not in STOP_WORDS:
                         term_hits[id] += 1
 
+        # Apply a linear coverage multiplier. Since scores already accumulate
+        # proportionally to N matching terms, multiplying by N gives an effective
+        # N*N = N^2 relative boost for full-coverage matches (1 term: 1x, 2: 4x, 3: 9x).
         for id in scores:
             if term_hits[id] > 1:
-                scores[id] *= term_hits[id] ** 2
+                scores[id] *= term_hits[id]
 
         return dict(scores)
     


### PR DESCRIPTION
The previous * 4 mid-loop amplifier compounded on each query token, making rankings sensitive to query term order. E.g. a query ["machine", "learning"] could produce different results than ["learning", "machine"].

Replaces it with a squared coverage multiplier applied once after accumulation: score *= term_hits^2. Documents matching N non-stop-word query terms get an N^2 boost (1 term: 1x, 2 terms: 4x, 3 terms: 9x), preserving the intent of preferring full-coverage matches while being fully order-independent.

Also smooths IDF from log(N/df) to log(1 + N/df) to prevent zero or negative values when a term appears in all documents.